### PR TITLE
Change BlocklyToFeature to extend BlocklyToJava - Feature Mod element

### DIFF
--- a/src/main/java/net/mcreator/blockly/feature/BlocklyToFeature.java
+++ b/src/main/java/net/mcreator/blockly/feature/BlocklyToFeature.java
@@ -19,14 +19,12 @@
 
 package net.mcreator.blockly.feature;
 
-import net.mcreator.blockly.BlocklyBlockUtil;
 import net.mcreator.blockly.BlocklyCompileNote;
-import net.mcreator.blockly.BlocklyToCode;
 import net.mcreator.blockly.IBlockGenerator;
-import net.mcreator.blockly.java.blocks.MCItemBlock;
-import net.mcreator.generator.Generator;
+import net.mcreator.blockly.java.BlocklyToJava;
 import net.mcreator.generator.template.TemplateGenerator;
 import net.mcreator.generator.template.TemplateGeneratorException;
+import net.mcreator.ui.blockly.BlocklyEditorType;
 import net.mcreator.ui.init.L10N;
 import net.mcreator.util.XMLUtil;
 import net.mcreator.workspace.Workspace;
@@ -34,71 +32,50 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.xml.sax.InputSource;
 
-import javax.xml.parsers.DocumentBuilderFactory;
-import java.io.StringReader;
-import java.text.ParseException;
 import java.util.List;
 
-public class BlocklyToFeature extends BlocklyToCode {
+public class BlocklyToFeature extends BlocklyToJava {
 	protected final Logger LOG = LogManager.getLogger("Blockly2Feature");
 
-	private final StringBuilder featureConfigurationCode;
+	private StringBuilder featureConfigurationCode;
 	private String featureType;
 
-	/**
-	 * @param workspace          <p>The {@link Workspace} executing the code</p>
-	 * @param firstBlockName     <p>The name of the start block</p>
-	 * @param sourceXML          <p>The XML code used by Blockly</p>
-	 * @param templateGenerator  <p>The folder location in each {@link Generator} containing the code template files<p>
-	 */
-	public BlocklyToFeature(Workspace workspace, String firstBlockName, String sourceXML,
-			TemplateGenerator templateGenerator, IBlockGenerator... externalGenerators)
-			throws TemplateGeneratorException {
-		super(workspace, templateGenerator, externalGenerators);
+	public BlocklyToFeature(Workspace workspace, String sourceXML, TemplateGenerator templateGenerator,
+			IBlockGenerator... externalGenerators) throws TemplateGeneratorException {
+		super(workspace, BlocklyEditorType.FEATURE.getStartBlockName(), sourceXML, templateGenerator,
+				externalGenerators);
+	}
+
+	@Override public void preInitialization() {
+		super.preInitialization();
 		featureConfigurationCode = new StringBuilder();
 		featureType = "";
+	}
 
-		blockGenerators.add(new MCItemBlock());
+	@Override public void preBlocksPlacement(Document doc, Element startBlock) {
+		super.preBlocksPlacement(doc, startBlock);
 
-		if (sourceXML != null) {
+		// Add the feature to the feature code
+		Element feature = XMLUtil.getFirstChildrenWithName(startBlock, "value");
+		if (feature != null) {
 			try {
-				final Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder()
-						.parse(new InputSource(new StringReader(sourceXML)));
-				doc.getDocumentElement().normalize();
-
-				Element start_block = BlocklyBlockUtil.getStartBlock(doc, firstBlockName);
-
-				// if there is no start block, we return empty string
-				if (start_block == null)
-					throw new ParseException("Could not find start block!", -1);
-
-				// Add the feature to the feature code
-				Element feature = XMLUtil.getFirstChildrenWithName(start_block, "value");
-				if (feature != null) {
-					featureConfigurationCode.append(directProcessOutputBlock(this, feature));
-					Element featureBlock = XMLUtil.getFirstChildrenWithName(feature, "block");
-					if (featureBlock != null)
-						this.featureType = featureBlock.getAttribute("type");
-				}
-				else
-					addCompileNote(new BlocklyCompileNote(BlocklyCompileNote.Type.ERROR,
-							L10N.t("blockly.errors.features.missing_feature")));
-
-				List<Element> base_blocks = BlocklyBlockUtil.getBlockProcedureStartingWithNext(start_block);
-				if (base_blocks.isEmpty())
-					addCompileNote(new BlocklyCompileNote(BlocklyCompileNote.Type.ERROR,
-							L10N.t("blockly.errors.features.missing_placement")));
-				processBlockProcedure(base_blocks);
+				featureConfigurationCode.append(directProcessOutputBlock(this, feature));
+				Element featureBlock = XMLUtil.getFirstChildrenWithName(feature, "block");
+				if (featureBlock != null)
+					this.featureType = featureBlock.getAttribute("type");
 			} catch (TemplateGeneratorException e) {
-				throw e;
-			} catch (Exception e) {
-				LOG.error(e.getMessage(), e);
-				addCompileNote(new BlocklyCompileNote(BlocklyCompileNote.Type.ERROR,
-						L10N.t("blockly.errors.exception_compiling", e.getMessage())));
+				e.printStackTrace();
 			}
-		}
+		} else
+			addCompileNote(new BlocklyCompileNote(BlocklyCompileNote.Type.ERROR,
+					L10N.t("blockly.errors.features.missing_feature")));
+	}
+
+	@Override public void postBlocksPlacement(Document doc, Element startBlock, List<Element> baseBlocks) {
+		if (baseBlocks.isEmpty())
+			addCompileNote(new BlocklyCompileNote(BlocklyCompileNote.Type.ERROR,
+					L10N.t("blockly.errors.features.missing_placement")));
 	}
 
 	public final String getFeatureConfigurationCode() {

--- a/src/main/java/net/mcreator/blockly/feature/BlocklyToFeature.java
+++ b/src/main/java/net/mcreator/blockly/feature/BlocklyToFeature.java
@@ -43,7 +43,7 @@ public class BlocklyToFeature extends BlocklyToJava {
 
 	public BlocklyToFeature(Workspace workspace, String sourceXML, TemplateGenerator templateGenerator,
 			IBlockGenerator... externalGenerators) throws TemplateGeneratorException {
-		super(workspace, BlocklyEditorType.FEATURE.getStartBlockName(), sourceXML, templateGenerator,
+		super(workspace, "feature_container", sourceXML, templateGenerator,
 				externalGenerators);
 	}
 
@@ -53,20 +53,16 @@ public class BlocklyToFeature extends BlocklyToJava {
 		featureType = "";
 	}
 
-	@Override public void preBlocksPlacement(Document doc, Element startBlock) {
+	@Override public void preBlocksPlacement(Document doc, Element startBlock) throws TemplateGeneratorException {
 		super.preBlocksPlacement(doc, startBlock);
 
 		// Add the feature to the feature code
 		Element feature = XMLUtil.getFirstChildrenWithName(startBlock, "value");
 		if (feature != null) {
-			try {
-				featureConfigurationCode.append(directProcessOutputBlock(this, feature));
-				Element featureBlock = XMLUtil.getFirstChildrenWithName(feature, "block");
-				if (featureBlock != null)
-					this.featureType = featureBlock.getAttribute("type");
-			} catch (TemplateGeneratorException e) {
-				e.printStackTrace();
-			}
+			featureConfigurationCode.append(directProcessOutputBlock(this, feature));
+			Element featureBlock = XMLUtil.getFirstChildrenWithName(feature, "block");
+			if (featureBlock != null)
+				this.featureType = featureBlock.getAttribute("type");
 		} else
 			addCompileNote(new BlocklyCompileNote(BlocklyCompileNote.Type.ERROR,
 					L10N.t("blockly.errors.features.missing_feature")));

--- a/src/main/java/net/mcreator/blockly/java/BlocklyToJava.java
+++ b/src/main/java/net/mcreator/blockly/java/BlocklyToJava.java
@@ -55,7 +55,7 @@ public class BlocklyToJava extends BlocklyToCode {
 			throws TemplateGeneratorException {
 		super(workspace, templateGenerator, externalGenerators);
 
-		addJavaBlocks();
+		preInitialization();
 
 		if (sourceXML != null) {
 			try {
@@ -70,14 +70,14 @@ public class BlocklyToJava extends BlocklyToCode {
 					throw new ParseException("Could not find start block!", -1);
 
 				// we execute extra actions needed before placing blocks
-				preBlocksPlacement(doc);
+				preBlocksPlacement(doc, start_block);
 
 				// find all blocks placed under start block
 				List<Element> base_blocks = BlocklyBlockUtil.getBlockProcedureStartingWithNext(start_block);
 				processBlockProcedure(base_blocks);
 
 				// we execute extra actions needed after blocks are placed
-				postBlocksPlacement(doc);
+				postBlocksPlacement(doc, start_block, base_blocks);
 
 			} catch (TemplateGeneratorException e) {
 				throw e;
@@ -93,17 +93,23 @@ public class BlocklyToJava extends BlocklyToCode {
 	 * <p>This method contains the code needing to be executed before blocks are placed.</p>
 	 *
 	 * @param doc Blockly XML document
+	 * @param startBlock The basic block of the editor used to get other blocks.
 	 */
-	public void preBlocksPlacement(Document doc) {}
+	public void preBlocksPlacement(Document doc, Element startBlock) {}
 
 	/**
 	 * <p>This method contains the code needing to be executed after blocks are placed.</p>
 	 *
 	 * @param doc Blockly XML document
+	 * @param startBlock The basic block of the editor used to get other blocks.
+	 * @param baseBlocks A list of all blocks placed under start block.
 	 */
-	public void postBlocksPlacement(Document doc) {}
+	public void postBlocksPlacement(Document doc, Element startBlock, List<Element> baseBlocks) {}
 
-	private void addJavaBlocks() {
+	/**
+	 * <p>This method is executed after the constructor is called, before the code is executed.</p>
+	 */
+	public void preInitialization() {
 		// add standard procedural blocks
 		blockGenerators.add(new PrintTextBlock());
 		blockGenerators.add(new IfBlock());

--- a/src/main/java/net/mcreator/blockly/java/BlocklyToJava.java
+++ b/src/main/java/net/mcreator/blockly/java/BlocklyToJava.java
@@ -95,7 +95,7 @@ public class BlocklyToJava extends BlocklyToCode {
 	 * @param doc Blockly XML document
 	 * @param startBlock The basic block of the editor used to get other blocks.
 	 */
-	public void preBlocksPlacement(Document doc, Element startBlock) {}
+	public void preBlocksPlacement(Document doc, Element startBlock) throws TemplateGeneratorException {}
 
 	/**
 	 * <p>This method contains the code needing to be executed after blocks are placed.</p>

--- a/src/main/java/net/mcreator/blockly/java/BlocklyToProcedure.java
+++ b/src/main/java/net/mcreator/blockly/java/BlocklyToProcedure.java
@@ -46,7 +46,7 @@ public class BlocklyToProcedure extends BlocklyToJava {
 		super(workspace, "event_trigger", sourceXML, templateGenerator, externalGenerators);
 	}
 
-	@Override public void preBlocksPlacement(Document doc) {
+	@Override public void preBlocksPlacement(Document doc, Element startBlock) {
 		if (doc != null) {
 			// first we load data from startblock
 			Element trigger = XMLUtil.getFirstChildrenWithName(BlocklyBlockUtil.getStartBlock(doc, "event_trigger"),
@@ -61,7 +61,7 @@ public class BlocklyToProcedure extends BlocklyToJava {
 		}
 	}
 
-	@Override public void postBlocksPlacement(Document doc) {
+	@Override public void postBlocksPlacement(Document doc, Element startBlock, List<Element> baseBlocks) {
 		if (getReturnType() != null) {
 			if (!ArrayUtils.contains(new ReturnBlock().getSupportedBlocks(), lastProceduralBlockType)) {
 				addCompileNote(new BlocklyCompileNote(BlocklyCompileNote.Type.ERROR,

--- a/src/main/java/net/mcreator/element/types/Feature.java
+++ b/src/main/java/net/mcreator/element/types/Feature.java
@@ -60,8 +60,8 @@ import java.util.List;
 					BlocklyLoader.INSTANCE.getFeatureBlockLoader().getDefinedBlocks(),
 					this.getModElement().getGenerator().getTemplateGeneratorFromName("features"), additionalData);
 
-			var blocklyToFeature = new BlocklyToFeature(this.getModElement().getWorkspace(), "feature_container",
-					this.featurexml, this.getModElement().getGenerator().getTemplateGeneratorFromName("features"),
+			var blocklyToFeature = new BlocklyToFeature(this.getModElement().getWorkspace(), this.featurexml,
+					this.getModElement().getGenerator().getTemplateGeneratorFromName("features"),
 					new ProceduralBlockCodeGenerator(blocklyBlockCodeGenerator),
 					new OutputBlockCodeGenerator(blocklyBlockCodeGenerator));
 

--- a/src/main/java/net/mcreator/ui/blockly/BlocklyEditorType.java
+++ b/src/main/java/net/mcreator/ui/blockly/BlocklyEditorType.java
@@ -22,8 +22,7 @@ package net.mcreator.ui.blockly;
 public enum BlocklyEditorType {
 
 	PROCEDURE("procedures", "ptpl", "event_trigger"),
-	AI_TASK("ai_setup", "aitpl", "aitasks_container"),
-	FEATURE("features", "ftpl", "feature_container");
+	AI_TASK("ai_setup", "aitpl", "aitasks_container");
 
 	private final String translationKey;
 	private final String extension;

--- a/src/main/java/net/mcreator/ui/blockly/BlocklyEditorType.java
+++ b/src/main/java/net/mcreator/ui/blockly/BlocklyEditorType.java
@@ -22,7 +22,8 @@ package net.mcreator.ui.blockly;
 public enum BlocklyEditorType {
 
 	PROCEDURE("procedures", "ptpl", "event_trigger"),
-	AI_TASK("ai_setup", "aitpl", "aitasks_container");
+	AI_TASK("ai_setup", "aitpl", "aitasks_container"),
+	FEATURE("features", "ftpl", "feature_container");
 
 	private final String translationKey;
 	private final String extension;

--- a/src/main/java/net/mcreator/ui/modgui/FeatureGUI.java
+++ b/src/main/java/net/mcreator/ui/modgui/FeatureGUI.java
@@ -143,8 +143,8 @@ public class FeatureGUI extends ModElementGUI<Feature> {
 
 		BlocklyToFeature blocklyToFeature;
 		try {
-			blocklyToFeature = new BlocklyToFeature(mcreator.getWorkspace(), "feature_container",
-					blocklyPanel.getXML(), null, new ProceduralBlockCodeGenerator(blocklyBlockCodeGenerator),
+			blocklyToFeature = new BlocklyToFeature(mcreator.getWorkspace(), blocklyPanel.getXML(),
+					null, new ProceduralBlockCodeGenerator(blocklyBlockCodeGenerator),
 					new OutputBlockCodeGenerator(blocklyBlockCodeGenerator));
 		} catch (TemplateGeneratorException e) {
 			return;


### PR DESCRIPTION
When I asked you [here ](https://github.com/MCreator/MCreator/pull/2528#discussion_r832614591) if it could use Blockly2Java instead of BlocklyToCode directly, you answered me you couldn't as you needed to execute something before the code execution.
I adapted a little bit (minor changes) `BlocklyToJava` and your `BlocklyToFeature`, so we can avoid repetitive code (the exact purpose of my recent changes with Blockly).

I did not add the `BlocklyEditorToolbar`, but it may be interesting to have it, so templates can be used in the future when complex features will be possible.